### PR TITLE
Added build-time generated version information.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blacklung"
 version = "0.0.1"
 authors = ["Michael Leandersson <tripokey@gmail.com>", "Niklas Thörne <notrupertthorne@gmail.com>"]
+build = "build.rs"
 
 description = "Minecraft server"
 repository = "https://github.com/xyrosource/blacklung"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 The Xyrosource Team.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// This build.rs script is inspired from
+// https://github.com/simias/pockystation/blob/master/build.rs
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let version_file = Path::new(&out_dir).join("version.rs");
+    let mut fil = File::create(&version_file).unwrap();
+
+    let cargo_version = env!("CARGO_PKG_VERSION").to_owned();
+
+    writeln!(fil, "pub const VERSION: &'static str = \
+                 \"{}\";", cargo_version).unwrap();
+}
+

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -24,7 +24,7 @@ mod version {
     // cargo metadata file.
     include!(concat!(env!("OUT_DIR"), "/version.rs"));
 }
-pub use self::version::VERSION;
+use self::version::VERSION;
 
 
 type PortType = Option<u16>;

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -18,6 +18,14 @@ pub mod errors {
 
 use self::errors::*;
 
+mod version {
+    // include the generated version file, containing the
+    // VERSION symbol with the version as defined in the
+    // cargo metadata file.
+    include!(concat!(env!("OUT_DIR"), "/version.rs"));
+}
+pub use self::version::VERSION;
+
 
 type PortType = Option<u16>;
 
@@ -31,9 +39,11 @@ Blacklung server.
 Usage:
     blacklung [--port=<port>] [--config=<configfile>]
     blacklung (-h | --help)
+    blacklung --version
 
 Options:
-    -h --help               Show this screen.
+    -h, --help              Show this screen.
+    --version               Print version and exit.
     --config=<CONFIGFILE>   Configuration file to use. [default: blacklung.cfg].
     --port=<PORT>           Port to bind to. Defaults to 12345, unless given as
                             configuration item or argument.
@@ -106,8 +116,11 @@ fn join(cfg: ConfigurationFile, args: Args) -> Result<Config> {
 /// arguments and default values. This function will Err upon malformed
 /// configuration items or agruments.
 pub fn get_config(root_logger: &Logger) -> Result<Config> {
-    let args: Args = Docopt::new(USAGE).and_then(|d| d.decode())
-        .chain_err(|| "Failed to parse command line arguments")?;
+    let args: Args = Docopt::new(USAGE)
+        .and_then(|docopt| docopt.version(Some(VERSION.to_owned())).parse())    // enable the version flag..
+        .and_then(|d| d.decode())                                               // parse the ArgvMap
+        .unwrap_or_else(|err| err.exit());                                      // exit on parse error, as Err(Help) and Err(Version
+                                                                                // is returned from the flags.
 
     let cfg =
         read_config(&args.flag_config).chain_err(|| "Failed to read the configuration file.")?;

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -11,7 +11,15 @@ extern crate slog_term;
 
 use slog::{DrainExt, Logger};
 
+mod version {
+    // include the generated version file, containing the
+    // VERSION symbol with the version as defined in the
+    // cargo metadata file.
+    include!(concat!(env!("OUT_DIR"), "/version.rs"));
+}
+pub use self::version::VERSION;
+
 pub fn setup() -> slog::Logger {
     let drain = slog_term::streamer().compact().build().fuse();
-    Logger::root(drain, o!("version" => "0.0.1"))
+    Logger::root(drain, o!("version" => VERSION))
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -17,7 +17,7 @@ mod version {
     // cargo metadata file.
     include!(concat!(env!("OUT_DIR"), "/version.rs"));
 }
-pub use self::version::VERSION;
+use self::version::VERSION;
 
 pub fn setup() -> slog::Logger {
     let drain = slog_term::streamer().compact().build().fuse();


### PR DESCRIPTION
* Static version fetched from cargo metadata.
* Added --version flag.
* Fixed bug in --help flag, where Err(Help) was chained, causing help
  screen to look like error.
* Use static version when logging version on application start-up.

Closes #27 